### PR TITLE
Remove carpe specific comments

### DIFF
--- a/.jenkins/ci.Jenkinsfile
+++ b/.jenkins/ci.Jenkinsfile
@@ -1,8 +1,8 @@
 def params = [
-    'ciVersion': 'main',                                // Version of the devops-jenkins-libraries that you want to use
-    'configLocation': '.jenkins/config.yaml'            // Location of your repo config file that contains specific build information
+    'ciVersion': 'main',
+    'configLocation': '.jenkins/config.yaml'
 ]
 
-library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+library "devops-jenkins-libraries@${params.ciVersion}"
 
-centralizedCI params                                    // Call the groovy scripts that will run the build
+centralizedCI params

--- a/.jenkins/config.yaml
+++ b/.jenkins/config.yaml
@@ -1,4 +1,3 @@
-# More details:  https://github.com/carpe/devops-jenkins-libraries/blob/main/resources/io/carpe/ci/exampleConfig.yaml
 projects:
   - name: sbt-codeartifact
     archetype: scala

--- a/.jenkins/release.Jenkinsfile
+++ b/.jenkins/release.Jenkinsfile
@@ -1,15 +1,8 @@
-/*
-This is the Jenkinsfile that every repository using CI should have to trigger a release.
-This should be placed in your repository at `.jenkins/release.Jenkinsfile`
-The items under params can change if needed.  Note that the changes
-will be applied to all projects in this repository.
-*/
-
 def params = [
-        'ciVersion'     : 'main',                       // Version of the devops-jenkins-libraries that you want to use
-        'configLocation': '.jenkins/config.yaml'        // Location of your repo config file that contains specific build information
+        'ciVersion'     : 'main',
+        'configLocation': '.jenkins/config.yaml'
 ]
 
-library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+library "devops-jenkins-libraries@${params.ciVersion}"
 
-releaseCI params                                        // Call the groovy scripts that will trigger the release
+releaseCI params


### PR DESCRIPTION
Since this is a public repo, we should remove comments that are "carpe specific" such as details about how the CI works.  Nothing in here is really a big deal, but still let's get rid of it.