### PR TITLE
chore: bump sbt to 1.12.1 to match CI image

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.12.1


### PR DESCRIPTION
Bumps sbt from 1.9.7 to 1.12.1 to match the devops-ci-scala CI image. Required for zinc compile cache key compatibility with the upcoming SBT cache feature.