### PR TITLE
chore: bump sbt to 1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,450 @@
 **/.ammonite/
 project/project
 project/metals.sbt
+# Extras
+.idea/
+**/.idea/
+spark-out*/
+spark-warehouse*/
+temp/
+tmp/
+
+# Created by https://www.toptal.com/developers/gitignore/api/sbt,java,maven,scala,spark,python,gradle,intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=sbt,java,maven,scala,spark,python,gradle,intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/
+
+# Cache file creation bug
+# See https://youtrack.jetbrains.com/issue/JBR-2257
+.idea/$CACHE_FILE$
+
+# CodeStream plugin
+# https://plugins.jetbrains.com/plugin/12206-codestream
+.idea/codestream.xml
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### SBT ###
+# Simple Build Tool
+# http://www.scala-sbt.org/release/docs/Getting-Started/Directories.html#configuring-version-control
+
+dist/*
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+.history
+.lib/
+.bloop
+.bsp
+.scannerwork
+
+### Scala ###
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+
+### Spark ###
+*#*#
+*.#*
+*.iml
+*.ipr
+*.pyc
+*.pyo
+*.swp
+*~
+.DS_Store
+.ensime
+.ensime_cache/
+.ensime_lucene
+.generated-mima*
+.pydevproject
+.scala_dependencies
+.settings
+/lib/
+R-unit-tests.log
+R/unit-tests.out
+R/cran-check.out
+R/pkg/vignettes/sparkr-vignettes.html
+R/pkg/tests/fulltests/Rplots.pdf
+build/*.jar
+build/apache-maven*
+build/scala*
+build/zinc*
+cache
+checkpoint
+conf/*.cmd
+conf/*.conf
+conf/*.properties
+conf/*.sh
+conf/*.xml
+conf/java-opts
+conf/slaves
+derby.log
+dev/create-release/*final
+dev/create-release/*txt
+dev/pr-deps/
+docs/_site
+docs/api
+sql/docs
+sql/site
+lint-r-report.log
+log/
+logs/
+project/build/target/
+project/plugins/lib_managed/
+project/plugins/project/build.properties
+project/plugins/src_managed/
+project/plugins/target/
+python/lib/pyspark.zip
+python/deps
+python/test_coverage/coverage_data
+python/test_coverage/htmlcov
+python/pyspark/python
+reports/
+scalastyle-on-compile.generated.xml
+scalastyle-output.xml
+scalastyle.txt
+spark-*-bin-*.tgz
+spark-tests.log
+streaming-tests.log
+unit-tests.log
+work/
+docs/.jekyll-metadata
+
+# For Hive
+TempStatsStore/
+metastore/
+metastore_db/
+sql/hive-thriftserver/test_warehouses
+warehouse/
+spark-warehouse/
+
+# For R session data
+.RData
+.RHistory
+.Rhistory
+*.Rproj
+*.Rproj.*
+
+.Rproj.user
+
+# For SBT
+.jvmopts
+
+
+### Gradle ###
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+# JDT-specific (Eclipse Java Development Tools)
+
+# End of https://www.toptal.com/developers/gitignore/api/sbt,java,maven,scala,spark,python,gradle,intellij

--- a/.jenkins/ci.Jenkinsfile
+++ b/.jenkins/ci.Jenkinsfile
@@ -1,0 +1,8 @@
+def params = [
+    'ciVersion': 'main',                                // Version of the devops-jenkins-libraries that you want to use
+    'configLocation': '.jenkins/config.yaml'            // Location of your repo config file that contains specific build information
+]
+
+library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+
+centralizedCI params                                    // Call the groovy scripts that will run the build

--- a/.jenkins/ci.Jenkinsfile
+++ b/.jenkins/ci.Jenkinsfile
@@ -1,8 +1,8 @@
 def params = [
-    'ciVersion': 'main',                                // Version of the devops-jenkins-libraries that you want to use
-    'configLocation': '.jenkins/config.yaml'            // Location of your repo config file that contains specific build information
+    'ciVersion': 'main',
+    'configLocation': '.jenkins/config.yaml'
 ]
 
-library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+library "devops-jenkins-libraries@${params.ciVersion}"
 
-centralizedCI params                                    // Call the groovy scripts that will run the build
+centralizedCI params

--- a/.jenkins/config.yaml
+++ b/.jenkins/config.yaml
@@ -1,0 +1,4 @@
+# More details:  https://github.com/carpe/devops-jenkins-libraries/blob/main/resources/io/carpe/ci/exampleConfig.yaml
+projects:
+  - name: sbt-codeartifact
+    archetype: scala

--- a/.jenkins/config.yaml
+++ b/.jenkins/config.yaml
@@ -1,4 +1,3 @@
-# More details:  https://github.com/carpe/devops-jenkins-libraries/blob/main/resources/io/carpe/ci/exampleConfig.yaml
 projects:
   - name: sbt-codeartifact
     archetype: scala

--- a/.jenkins/release.Jenkinsfile
+++ b/.jenkins/release.Jenkinsfile
@@ -1,15 +1,8 @@
-/*
-This is the Jenkinsfile that every repository using CI should have to trigger a release.
-This should be placed in your repository at `.jenkins/release.Jenkinsfile`
-The items under params can change if needed.  Note that the changes
-will be applied to all projects in this repository.
-*/
-
 def params = [
-        'ciVersion'     : 'main',                       // Version of the devops-jenkins-libraries that you want to use
-        'configLocation': '.jenkins/config.yaml'        // Location of your repo config file that contains specific build information
+        'ciVersion'     : 'main',
+        'configLocation': '.jenkins/config.yaml'
 ]
 
-library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+library "devops-jenkins-libraries@${params.ciVersion}"
 
-releaseCI params                                        // Call the groovy scripts that will trigger the release
+releaseCI params

--- a/.jenkins/release.Jenkinsfile
+++ b/.jenkins/release.Jenkinsfile
@@ -1,0 +1,15 @@
+/*
+This is the Jenkinsfile that every repository using CI should have to trigger a release.
+This should be placed in your repository at `.jenkins/release.Jenkinsfile`
+The items under params can change if needed.  Note that the changes
+will be applied to all projects in this repository.
+*/
+
+def params = [
+        'ciVersion'     : 'main',                       // Version of the devops-jenkins-libraries that you want to use
+        'configLocation': '.jenkins/config.yaml'        // Location of your repo config file that contains specific build information
+]
+
+library "devops-jenkins-libraries@${params.ciVersion}"  // Load the version of the library as defined in params.ciVersion
+
+releaseCI params                                        // Call the groovy scripts that will trigger the release

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.12.1


### PR DESCRIPTION
Bumps `sbt.version` from 1.9.7 to `1.12.1` in `project/build.properties`.

Required for SBT dependency cache compatibility — the cache key includes the sbt version, so repos on older versions won't benefit from the S3 build cache once devops-jenkins-libraries#239 merges.